### PR TITLE
fix(auth): Handle non-JSON error responses gracefully

### DIFF
--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -68,8 +68,8 @@ export function useLoginMutation() {
       });
 
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || "Login failed");
+        const errorText = await response.text();
+        throw new Error(errorText || "Login failed");
       }
 
       return response.json();
@@ -101,8 +101,8 @@ export function useRegisterMutation() {
       });
 
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.message || "Registration failed");
+        const errorText = await response.text();
+        throw new Error(errorText || "Registration failed");
       }
 
       return response.json();


### PR DESCRIPTION
The login and register mutations would crash the application with a "Unexpected token" error if the server returned a non-JSON response (e.g., an HTML error page) on failure. This happened because the code unconditionally called `response.json()` on the error response.

This change modifies the error handling in `useLoginMutation` and `useRegisterMutation` to first read the error response as text using `response.text()`. This prevents the JSON parsing crash and ensures the actual server error message is used in the thrown error, which improves debugging.