### PR TITLE
fix(vercel): remove invalid runtime version from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,7 @@
   "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist/public",
   "functions": {
-    "api/index.ts": {
-      "runtime": "nodejs20.x"
-    }
+    "api/index.ts": {}
   },
   "rewrites": [
     { 


### PR DESCRIPTION
- Suppression de la configuration runtime nodejs20.x qui causait l'erreur 'Function Runtimes must have a valid version'
- Vercel détectera automatiquement la version Node.js depuis package.json engines
- La configuration functions reste présente mais sans runtime spécifique
- Build testé et validé avec npm run vercel-build